### PR TITLE
Käytä listan sijaan jonoa `ConsoleIO`-luokassa

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
 - tämän jälkeen voit käyttää komentoja ```poetry run invoke start``` ohjelman ajamiseen, ```poetry run invoke test``` testaamiseen, ```poetry run invoke coverage``` kattavuusraportin tulostamiseen ja ```poetry run invoke clean``` koodin muotoiluun.
 
 ## Definition of Done
+
   - All acceptance criteria are met
   - All necessary tests have been successfully completed
   - We have had multiple check the work

--- a/src/services/console_io.py
+++ b/src/services/console_io.py
@@ -1,7 +1,11 @@
 # pylint: skip-file
+
+from collections import deque
+
+
 class ConsoleIO:
     def __init__(self, inputs=None):
-        self.inputs = inputs or []
+        self.inputs = inputs or deque()
         self.outputs = []
 
     def write(self, value):
@@ -10,7 +14,7 @@ class ConsoleIO:
 
     def read(self):
         if len(self.inputs) > 0:
-            return self.inputs.pop(0)
+            return self.inputs.popleft()
         return ""
 
     def add_input(self, value, val=False):


### PR DESCRIPTION
Viikon 6 tehtävä 6

Refaktoroitu `ConsoleIO`-luokka käyttämään `deque`-jonoa listan sijaan, jotta ei tarvitse poistaa listasta tiettyä alkiota indeksin perusteella.